### PR TITLE
Update 2017 03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+/packaging/
+
+*.pyc
+*.pyo
+*.pwd
+
 # Ignore Mac DS_Store files
 .DS_Store

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,18 +1,18 @@
 Copyright (c) 2015, Jamie Unwin (jamieu)
 
-Sections of library code based on a previous project by Johannes Baiter (jbaiter)  
+Sections of library code based on a previous project by Johannes Baiter (jbaiter)
 https://github.com/jbaiter/plugin.video.mubi
 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met: 
+modification, are permitted provided that the following conditions are met:
 
 1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer. 
+   list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution. 
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+ADDON = plugin.video.mubi
+
+SOURCE_FILES = addon.xml addon.py
+SOURCE_FILES += fanart.jpg icon.png
+SOURCE_FILES += README.md LICENSE
+SOURCE_FILES += resources/__init__.py resources/settings.xml
+SOURCE_FILES += resources/language/English/strings.xml
+SOURCE_FILES += resources/lib/__init__.py resources/lib/mubi.py
+
+PACKAGING_DIR = packaging
+PACKAGE_FILE = $(PACKAGING_DIR)/$(ADDON).zip
+
+DIST_FILES = $(addprefix $(PACKAGING_DIR)/$(ADDON)/,$(SOURCE_FILES))
+
+all: dist
+
+dist: $(PACKAGE_FILE)
+
+clean:
+	rm -f $(PACKAGE_FILE)
+	rm -Rf $(PACKAGING_DIR)
+
+$(PACKAGE_FILE): $(DIST_FILES)
+	cd $(PACKAGING_DIR) && zip -9r $(ADDON).zip $(ADDON)
+	@echo "Add-on package created at $(PACKAGE_FILE)"
+
+$(PACKAGING_DIR)/$(ADDON)/%: ./%
+	mkdir -p `dirname $@`
+	cp -f $< $@
+
+.PHONY: dist

--- a/addon.py
+++ b/addon.py
@@ -26,6 +26,7 @@ def index():
 
 @plugin.route('/play/<identifier>')
 def play_film(identifier):
+    mubi.enable_film(identifier)
     return plugin.set_resolved_url(mubi.get_play_url(identifier))
 
 

--- a/addon.py
+++ b/addon.py
@@ -27,7 +27,8 @@ def index():
 @plugin.route('/play/<identifier>')
 def play_film(identifier):
     mubi.enable_film(identifier)
-    return plugin.set_resolved_url(mubi.get_play_url(identifier))
+    mubi_url = mubi.get_play_url(identifier)
+    return plugin.set_resolved_url(mubi_url)
 
 
 if __name__ == '__main__':

--- a/addon.py
+++ b/addon.py
@@ -16,12 +16,12 @@ mubi.login(plugin.get_setting("username", unicode), plugin.get_setting("password
 def index():
     films = mubi.now_showing()
     items = [{
-			'label': film.title, 
-			'is_playable': True,
-            'path': plugin.url_for('play_film', identifier=film.mubi_id),
-          	'thumbnail': film.artwork,
-          	'info': film.metadata._asdict()
-    	} for film in films] 
+        'label': film.title,
+        'is_playable': True,
+        'path': plugin.url_for('play_film', identifier=film.mubi_id),
+        'thumbnail': film.artwork,
+        'info': film.metadata._asdict()
+    } for film in films]
     return items
 
 @plugin.route('/play/<identifier>')

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -122,26 +122,11 @@ class Mubi(object):
             films.append(f)
         return films
 
-    def is_film_available(self, name):
+    def enable_film(self, name):
         # Sometimes we have to load a prescreen page first before we can retrieve the film's secure URL
         # ie. https://mubi.com/films/lets-get-lost/prescreen --> https://mubi.com/films/lets-get-lost/watch
         self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
-        return True
-
-        #if not self._session.get(self._mubi_urls["video"] % name):
-        #    prescreen_page = self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
-        #    if not prescreen_page:
-        #        raise Exception("Oops, something went wrong while scraping :(")
-        #    elif self._regexps["watch_page"].match(prescreen_page.url):
-        #        return True
-        #    else:
-        #        availability = BS(prescreen_page.content).find("div", "film_viewable_status ").text
-        #        return not "Not Available to watch" in availability
-        #else:
-        #    return True
 
     def get_play_url(self, name):
-        if not self.is_film_available(name):
-            raise Exception("This film is not available.")
         return self._session.get(self._mubi_urls["video"] % name).content
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -16,19 +16,19 @@ class Mubi(object):
     _URL_MUBI_SECURE  = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
     _regexps = {
-	            "watch_page":  re.compile(r"^.*/watch$"),
-                "image_url":  re.compile(r"\((.*)\)"),
-                "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
-               }
+        "watch_page":  re.compile(r"^.*/watch$"),
+        "image_url":  re.compile(r"\((.*)\)"),
+        "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
+    }
     _mubi_urls = {
-                  "login":      urljoin(_URL_MUBI_SECURE, "login"),
-                  "session":    urljoin(_URL_MUBI_SECURE, "session"),
-                  "nowshowing": urljoin(_URL_MUBI, "films/showing"),
-                  "video":      urljoin(_URL_MUBI, "films/%s/secure_url"),
-                  "prescreen":  urljoin(_URL_MUBI, "films/%s/watch"),
-                  "filmdetails": urljoin(_URL_MUBI, "films/%s"),
-                  "logout":     urljoin(_URL_MUBI, "logout"),
-                 }
+        "login":      urljoin(_URL_MUBI_SECURE, "login"),
+        "session":    urljoin(_URL_MUBI_SECURE, "session"),
+        "nowshowing": urljoin(_URL_MUBI, "films/showing"),
+        "video":      urljoin(_URL_MUBI, "films/%s/secure_url"),
+        "prescreen":  urljoin(_URL_MUBI, "films/%s/watch"),
+        "filmdetails": urljoin(_URL_MUBI, "films/%s"),
+        "logout":     urljoin(_URL_MUBI, "logout"),
+    }
 
     def __init__(self):
         self._logger = logging.getLogger('mubi.Mubi')
@@ -49,9 +49,9 @@ class Mubi(object):
                            'session[password]': password,
                            'x': 0,
                            'y': 0}
-                           
+
         self._logger.debug("Logging in as user '%s', auth token is '%s'" % (username, auth_token))
-        
+
         r = self._session.post(self._mubi_urls["session"], data=session_payload)
         if r.status_code == 302:
             self._logger.debug("Login succesful")
@@ -64,7 +64,7 @@ class Mubi(object):
         items = [x for x in BS(page.content).findAll("article")]
         for x in items:
 
-            # core 
+            # core
             mubi_id   = x.find('a', {"data-filmid": True}).get("data-filmid")
             title     = x.find('h1').text
 
@@ -83,7 +83,7 @@ class Mubi(object):
                 country = None
                 year = None
 
-			# artwork
+            # artwork
             artStyle = x.find('div', {"style": True}).get("style")
             urlMatch = self._regexps["image_url"].search(artStyle)
             if urlMatch:
@@ -105,11 +105,11 @@ class Mubi(object):
 
             # metadata - ideally need to scrape this from the film page or a JSON API
             metadata = Metadata(
-                title=title, 
-                director=director, 
-                year=year, 
-                duration=None, 
-                country=country, 
+                title=title,
+                director=director,
+                year=year,
+                duration=None,
+                country=country,
                 plotoutline="",
                 plot=synopsis,
                 overlay=6 if hd else 0
@@ -121,11 +121,11 @@ class Mubi(object):
         return films
 
     def is_film_available(self, name):
-        # Sometimes we have to load a prescreen page first before we can retrieve the film's secure URL  
-        # ie. https://mubi.com/films/lets-get-lost/prescreen --> https://mubi.com/films/lets-get-lost/watch  
-        self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True) 
+        # Sometimes we have to load a prescreen page first before we can retrieve the film's secure URL
+        # ie. https://mubi.com/films/lets-get-lost/prescreen --> https://mubi.com/films/lets-get-lost/watch
+        self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
         return True
-        
+
         #if not self._session.get(self._mubi_urls["video"] % name):
         #    prescreen_page = self._session.head(self._mubi_urls["prescreen"] % name, allow_redirects=True)
         #    if not prescreen_page:

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -90,15 +90,11 @@ class Mubi(object):
             else:
                 artwork = None
 
-            # format a title with the year included for list_view
-            #listview_title = u'{0} ({1})'.format(title, year)
-            listview_title = title
 
             synopsis = x.find('p').text
 
             if x.find('i', {"aria-label": "HD"}):
                 hd = True
-                listview_title = title + " [HD]"
             else:
                 hd = False
 
@@ -113,6 +109,12 @@ class Mubi(object):
                 plot=synopsis,
                 overlay=6 if hd else 0
             )
+
+            # format a title with the year included for list_view
+            #listview_title = u'{0} ({1})'.format(title, year)
+            listview_title = title
+            if hd:
+                listview_title += " [HD]"
 
             f = Film(listview_title, mubi_id, artwork, metadata)
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -15,7 +15,6 @@ class Mubi(object):
     _URL_MUBI         = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
     _regexps = {
-        "watch_page":  re.compile(r"^.*/watch$"),
         "image_url":  re.compile(r"\((.*)\)"),
         "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
     }

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -90,8 +90,9 @@ class Mubi(object):
             else:
                 artwork = None
 
+            plotoutline = x.find('p').text
 
-            synopsis = x.find('p').text
+            plot = "" # TODO: access film page to read the full plot
 
             if x.find('i', {"aria-label": "HD"}):
                 hd = True
@@ -105,8 +106,8 @@ class Mubi(object):
                 year=year,
                 duration=None,
                 country=country,
-                plotoutline="",
-                plot=synopsis,
+                plotoutline=plotoutline,
+                plot=plot,
                 overlay=6 if hd else 0
             )
 

--- a/resources/lib/mubi.py
+++ b/resources/lib/mubi.py
@@ -12,8 +12,7 @@ Film      = namedtuple('Film', ['title', 'mubi_id', 'artwork', 'metadata'])
 Metadata  = namedtuple('Metadata', ['title', 'director', 'year', 'duration', 'country', 'plotoutline', 'plot', 'overlay'])
 
 class Mubi(object):
-    _URL_MUBI         = "http://mubi.com"
-    _URL_MUBI_SECURE  = "https://mubi.com"
+    _URL_MUBI         = "https://mubi.com"
     _USER_AGENT       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2"
     _regexps = {
         "watch_page":  re.compile(r"^.*/watch$"),
@@ -21,8 +20,8 @@ class Mubi(object):
         "country_year":  re.compile(r"(.*)\, ([0-9]{4})")
     }
     _mubi_urls = {
-        "login":      urljoin(_URL_MUBI_SECURE, "login"),
-        "session":    urljoin(_URL_MUBI_SECURE, "session"),
+        "login":      urljoin(_URL_MUBI, "login"),
+        "session":    urljoin(_URL_MUBI, "session"),
         "nowshowing": urljoin(_URL_MUBI, "films/showing"),
         "video":      urljoin(_URL_MUBI, "films/%s/secure_url"),
         "prescreen":  urljoin(_URL_MUBI, "films/%s/watch"),


### PR DESCRIPTION
An update to the scraper code to make the plugin compatible with the current Mubi website.

The new code will properly inspect the pages and find the correct "secure url". That address points to a playlist in DASH/M3U (depends on the movie). In theory these playlists are supported by Kodi 17+ but I could not get them to work. Somebody with more knowledge than me will make them work in few minutes.

These commits require PR #14 to be merged.